### PR TITLE
Nix puppeteer container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,19 +24,8 @@ jobs:
         with:
           node-version: 12
 
-      - name: npm ci
-        uses: ianwalter/puppeteer-container@v4.0.0
-        with:
-          args: npm ci
-
+      - run: npm ci
       - run: npm run lint
       - run: npm test
-
-      - if: matrix.browser == 'puppeteer'
-        name: npm run cucumber
-        uses: ianwalter/puppeteer-container@v4.0.0
-        with:
-          args: npm run cucumber
-
-      - if: matrix.browser != 'puppeteer'
-        run: npm run cucumber
+      - name: npm run features
+        run: npm run features -- --publish

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -35,12 +35,10 @@ jobs:
         with:
           node-version: 12
 
-      - name: npm ci
-        uses: ianwalter/puppeteer-container@v4.0.0
-        with:
-          args: npm ci
+      - run: npm ci
 
-      - name: cucumber - ${{ matrix.browser }}
-        uses: ianwalter/puppeteer-container@v4.0.0
-        with:
-          args: "npx cucumber-js -r src/index.js ${{ github.event.inputs.feature-files }} ${{ github.event.inputs.cucumber-args }}"
+      - name: cucumber
+        run: |
+          npm run cucumber -- \
+            ${{ github.event.inputs.feature-files }} \
+            ${{ github.event.inputs.cucumber-args }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "test": "jest",
-    "cucumber": "cucumber-js --publish-quiet -r src/index.js features/**/*.feature",
+    "features": "npm run cucumber -- features/**/*.feature",
+    "cucumber": "cucumber-js --publish-quiet --require src/index.js",
     "lint": "standard src __tests__"
   }
 }

--- a/src/world.js
+++ b/src/world.js
@@ -32,7 +32,6 @@ module.exports = class World {
 
   static async closeAll () {
     if (instances.length) {
-      console.warn('>>> closing %d instances', instances.length)
       while (instances.length) {
         await instances.pop().close()
       }
@@ -72,9 +71,6 @@ module.exports = class World {
       key: SELENIUM_KEY,
       capabilities
     }, webdriverOptions)
-    if (options.logLevel === 'trace' || options.logLevel === 'debug') {
-      console.warn('getBrowser() options:', options)
-    }
     return remote(options)
   }
 


### PR DESCRIPTION
This removes the puppeteer-specific Docker container image from our Actions workflows, since we're not running puppeteer (headless Chrome) in CI anymore. I've also tidied up the npm scripts situation and removed some unnecessary console logging from our "world" class.